### PR TITLE
Update method signature according to swift 4.2

### DIFF
--- a/src/ios/AppDelegate+NFC.swift
+++ b/src/ios/AppDelegate+NFC.swift
@@ -10,7 +10,7 @@ extension AppDelegate {
     
     override open func application(_ application: UIApplication,
                      continue userActivity: NSUserActivity,
-                     restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+                     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         
         NSLog("Extending UIApplicationDelegate")
         


### PR DESCRIPTION
With Swift 4.2 restorationHandler went from being ([Any]?) -> Void to ([UIUserActivityRestoring]?) -> Void.